### PR TITLE
hotfix: 모듈을 가져오지 못하는 문제 해결

### DIFF
--- a/client/src/components/SectionContainer/index.js
+++ b/client/src/components/SectionContainer/index.js
@@ -1,9 +1,9 @@
 import './styles.scss';
 import { element } from 'utils/element';
 import MonthBar from 'components/MonthBar';
-import ActivitySection from 'components/sections/ActivitySection';
-import CalendarSection from 'components/sections/CalendarSection';
-import StatisticSection from 'components/sections/StatisticSection';
+import ActivitySection from 'components/Sections/ActivitySection';
+import CalendarSection from 'components/Sections/CalendarSection';
+import StatisticSection from 'components/Sections/StatisticSection';
 import { store } from 'models/store';
 
 export default class SectionContainer {


### PR DESCRIPTION
## PR 요약

> 해당 PR이 어떤 PR인지에 대한 간략한 설명을 추가합니다.

`section` 디렉토리가 `Section` 으로 대문자로 변경되면서, 모듈을 import 해올 때 Section으로 지정해줘야 했습니다.
개발 환경시에는 cache가 남아 있어서 문제가 없었지만 배포하면서 이 에러가 발생하여 이를 해결했습니다.
